### PR TITLE
Update fluentd to 0.14.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN yum update -y && \
     yum clean all
 
 ENV LD_LIBRARY_PATH /opt/rh/rh-ruby23/root/usr/lib64
-ENV FLUENTD_VERSION 0.14.6
+ENV FLUENTD_VERSION 0.14.8
 RUN scl enable rh-ruby23 'gem update --system --no-document' && \
     scl enable rh-ruby23 'gem install --no-document json_pure jemalloc' && \
     scl enable rh-ruby23 "gem install --no-document fluentd -v ${FLUENTD_VERSION}" && \


### PR DESCRIPTION
There are important changes in 0.14.7, namely options to rotate fluentd's own logs, compression and a fix for https://github.com/fluent/fluentd/issues/1229

Using 0.14.8 because it is the latest, with another minor fix.
